### PR TITLE
Add item detail view for customer catalog

### DIFF
--- a/app/src/main/java/com/example/rahmatmas/data/supabase/db/SupabaseStock.kt
+++ b/app/src/main/java/com/example/rahmatmas/data/supabase/db/SupabaseStock.kt
@@ -14,4 +14,4 @@ data class SupabaseStock(
     val photo_path: String? = null,
     val created_at: String? = null,
     val updated_at: String? = null
-)
+) : java.io.Serializable

--- a/app/src/main/java/com/example/rahmatmas/ui/RahmatMasApp.kt
+++ b/app/src/main/java/com/example/rahmatmas/ui/RahmatMasApp.kt
@@ -44,6 +44,8 @@ import com.example.rahmatmas.ui.admin.stock.stocklist.StockListScreen
 import com.example.rahmatmas.ui.admin.transactionhistory.TransactionHistoryScreen
 import com.example.rahmatmas.ui.admin.transactionrecording.TransactionRecordingScreen
 import com.example.rahmatmas.ui.costumer.catalog.CatalogScreen
+import com.example.rahmatmas.ui.costumer.catalog.CatalogDetailScreen
+import com.example.rahmatmas.data.supabase.db.SupabaseStock
 import com.example.rahmatmas.ui.costumer.home.HomeCostumerScreen
 import com.example.rahmatmas.ui.costumer.login.LoginCustomerScreen
 import kotlinx.coroutines.flow.first
@@ -226,8 +228,21 @@ fun RahmatMasApp(
 
                 composable("catalogcostumer"){
                     CatalogScreen(
-                        onOrderClick = {}
+                        onProductClick = { stock ->
+                            navController.currentBackStackEntry?.savedStateHandle?.set("stock", stock)
+                            navController.navigate("catalogdetailcostumer")
+                        },
                     )
+                }
+
+                composable("catalogdetailcostumer"){
+                    val stock = navController.previousBackStackEntry?.savedStateHandle?.get<SupabaseStock>("stock")
+                    stock?.let {
+                        CatalogDetailScreen(
+                            stock = it,
+                            onBackClick = { navController.navigateUp() }
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/example/rahmatmas/ui/costumer/catalog/CatalogDetailScreen.kt
+++ b/app/src/main/java/com/example/rahmatmas/ui/costumer/catalog/CatalogDetailScreen.kt
@@ -1,0 +1,198 @@
+package com.example.rahmatmas.ui.costumer.catalog
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.ShoppingCart
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import coil.compose.rememberAsyncImagePainter
+import com.example.rahmatmas.data.supabase.db.SupabaseStock
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CatalogDetailScreen(
+    stock: SupabaseStock,
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+    val viewModel: CatalogViewModel = viewModel(
+        factory = CatalogViewModelFactory(context)
+    )
+    val uiState by viewModel.uiState.collectAsState()
+
+    LaunchedEffect(Unit) {
+        if (uiState.goldPrice == null) {
+            viewModel.fetchGoldPrice()
+        }
+    }
+
+    val calculatedPrice = viewModel.calculatePrice(stock)
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = {
+                    Text(
+                        text = "Detail Barang",
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 18.sp
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(
+                            imageVector = Icons.Default.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                    containerColor = Color(0xFFFF9800)
+                )
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = stock.nama_barang,
+                fontWeight = FontWeight.Bold,
+                fontSize = 20.sp,
+                modifier = Modifier.fillMaxWidth(),
+                textAlign = TextAlign.Start
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            if (!stock.photo_path.isNullOrEmpty()) {
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(250.dp),
+                    shape = RoundedCornerShape(12.dp)
+                ) {
+                    Image(
+                        painter = rememberAsyncImagePainter(stock.photo_path),
+                        contentDescription = null,
+                        modifier = Modifier.fillMaxSize(),
+                        contentScale = ContentScale.Crop
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(
+                    containerColor = Color(0xFFF5F5F5)
+                )
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    DetailRow(label = "Kadar Emas", value = stock.kadar_emas)
+                    DetailRow(label = "Berat", value = "${stock.berat_emas} gram")
+                    DetailRow(label = "Stok", value = "${stock.jumlah_stok} pcs")
+                    DetailRow(label = "Ongkos/gram", value = viewModel.formatCurrency(stock.ongkos_per_gram))
+                }
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+            if (calculatedPrice != null) {
+                Text(
+                    text = viewModel.formatCurrency(calculatedPrice),
+                    fontSize = 22.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = Color(0xFFFF9800)
+                )
+                Text(
+                    text = "Total Harga",
+                    fontSize = 14.sp,
+                    color = Color.Gray
+                )
+            } else {
+                Text(
+                    text = "Memuat harga...",
+                    fontSize = 14.sp,
+                    color = Color.Gray
+                )
+            }
+            Spacer(modifier = Modifier.height(24.dp))
+            Button(
+                onClick = { /* TODO: Implement order flow */ },
+                colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFFF9800)),
+                shape = RoundedCornerShape(8.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Icon(
+                    imageVector = Icons.Default.ShoppingCart,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp)
+                )
+                Spacer(modifier = Modifier.size(8.dp))
+                Text(
+                    text = "Order",
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DetailRow(label: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text = label,
+            fontSize = 14.sp,
+            color = Color.Gray
+        )
+        Text(
+            text = value,
+            fontSize = 14.sp,
+            fontWeight = FontWeight.Medium
+        )
+    }
+}
+

--- a/app/src/main/java/com/example/rahmatmas/ui/costumer/catalog/CatalogScreen.kt
+++ b/app/src/main/java/com/example/rahmatmas/ui/costumer/catalog/CatalogScreen.kt
@@ -20,12 +20,10 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.clickable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material.icons.filled.ShoppingCart
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
@@ -68,7 +66,7 @@ import com.example.rahmatmas.data.supabase.db.SupabaseStock
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CatalogScreen(
-    onOrderClick: (SupabaseStock) -> Unit,
+    onProductClick: (SupabaseStock) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
@@ -384,7 +382,7 @@ fun CatalogScreen(
                         items(stocks) { stock ->
                             CatalogItem(
                                 stock = stock,
-                                onOrderClick = { onOrderClick(stock) },
+                                onItemClick = { onProductClick(stock) },
                                 viewModel = viewModel
                             )
                         }
@@ -398,19 +396,18 @@ fun CatalogScreen(
 @Composable
 fun CatalogItem(
     stock: SupabaseStock,
-    onOrderClick: () -> Unit,
+    onItemClick: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: CatalogViewModel
 ) {
-//    val uiState by viewModel.uiState.collectAsState()
-
     Card(
         modifier = modifier
             .fillMaxWidth()
             .shadow(
                 4.dp,
                 shape = RoundedCornerShape(12.dp),
-            ),
+            )
+            .clickable(onClick = onItemClick),
         colors = CardDefaults.cardColors(
             containerColor = Color.White
         ),
@@ -419,16 +416,6 @@ fun CatalogItem(
         Column(
             modifier = Modifier.padding(12.dp)
         ) {
-            Text(
-                text = stock.nama_barang,
-                fontWeight = FontWeight.Bold,
-                fontSize = 12.sp,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-
-            // Photo (if exists)
             if (!stock.photo_path.isNullOrEmpty()) {
                 Card(
                     modifier = Modifier
@@ -446,96 +433,25 @@ fun CatalogItem(
                 Spacer(modifier = Modifier.height(8.dp))
             }
 
-            // Product specifications
-            Card(
-                modifier = Modifier.fillMaxWidth(),
-                colors = CardDefaults.cardColors(
-                    containerColor = Color(0xFFF5F5F5)
-                )
-            ) {
-                Column(
-                    modifier = Modifier.padding(12.dp)
-                ) {
-                    Text(
-                        text = "Spesifikasi",
-                        fontWeight = FontWeight.Medium,
-                        fontSize = 12.sp,
-                        color = Color(0xFFFF9800)
-                    )
-                    Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = stock.nama_barang,
+                fontWeight = FontWeight.Bold,
+                fontSize = 12.sp,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
 
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween
-                    ) {
-                        Text(
-                            text = "Kadar Emas:",
-                            fontSize = 10.sp,
-                            color = Color.Gray
-                        )
-                        Text(
-                            text = stock.kadar_emas,
-                            fontSize = 10.sp,
-                            fontWeight = FontWeight.Medium
-                        )
-                    }
+            Spacer(modifier = Modifier.height(4.dp))
 
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween
-                    ) {
-                        Text(
-                            text = "Berat:",
-                            fontSize = 10.sp,
-                            color = Color.Gray
-                        )
-                        Spacer(modifier = Modifier.width(2.dp))
-                        Text(
-                            text = "${stock.berat_emas} gram",
-                            fontSize = 10.sp,
-                            fontWeight = FontWeight.Medium
-                        )
-                    }
+            Text(
+                text = "Kadar ${stock.kadar_emas}",
+                fontSize = 10.sp,
+                color = Color.Gray
+            )
 
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween
-                    ) {
-                        Text(
-                            text = "Stok Tersedia:",
-                            fontSize = 10.sp,
-                            color = Color.Gray
-                        )
-                        Text(
-                            text = "${stock.jumlah_stok} Pcs",
-                            fontSize = 10.sp,
-                            fontWeight = FontWeight.Medium
-                        )
-                    }
+            Spacer(modifier = Modifier.height(4.dp))
 
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween
-                    ) {
-                        Text(
-                            text = "Ongkos/gram:",
-                            fontSize = 10.sp,
-                            color = Color.Gray
-                        )
-                        Text(
-                            text = viewModel.formatCurrency(stock.ongkos_per_gram),
-                            fontSize = 10.sp,
-                            fontWeight = FontWeight.Medium
-                        )
-                    }
-                }
-            }
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            // Price info and order button
             val calculatedPrice = viewModel.calculatePrice(stock)
-
             if (calculatedPrice != null) {
                 Text(
                     text = viewModel.formatCurrency(calculatedPrice),
@@ -543,40 +459,11 @@ fun CatalogItem(
                     fontWeight = FontWeight.Bold,
                     color = Color(0xFFFF9800)
                 )
-                Text(
-                    text = "Total Harga",
-                    fontSize = 10.sp,
-                    color = Color.Gray
-                )
             } else {
                 Text(
                     text = "Memuat harga...",
                     fontSize = 12.sp,
                     color = Color.Gray
-                )
-            }
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            Button(
-                onClick = onOrderClick,
-                enabled = stock.jumlah_stok > 0,
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = Color(0xFFFF9800),
-                    disabledContainerColor = Color.Gray
-                ),
-                shape = RoundedCornerShape(8.dp)
-            ) {
-                Icon(
-                    imageVector = Icons.Default.ShoppingCart,
-                    contentDescription = null,
-                    modifier = Modifier.size(16.dp)
-                )
-                Spacer(modifier = Modifier.width(4.dp))
-                Text(
-                    text = if (stock.jumlah_stok > 0) "Order" else "Habis",
-                    fontSize = 14.sp,
-                    fontWeight = FontWeight.Medium
                 )
             }
         }


### PR DESCRIPTION
## Summary
- simplify catalog item cards to show name, image, gold purity and price
- add dedicated catalog detail screen with full info and order action
- enable navigation to detail screen and make SupabaseStock serializable

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ddc060e908331856bf6f1a095b5bd