### PR TITLE
feat: store order items separately

### DIFF
--- a/app/src/main/java/com/example/rahmatmas/data/repository/OrderRepository.kt
+++ b/app/src/main/java/com/example/rahmatmas/data/repository/OrderRepository.kt
@@ -2,6 +2,8 @@ package com.example.rahmatmas.data.repository
 
 import com.example.rahmatmas.data.supabase.SupabaseModule
 import com.example.rahmatmas.data.supabase.db.SupabaseOrder
+import com.example.rahmatmas.data.supabase.db.SupabaseOrderItem
+import com.example.rahmatmas.data.supabase.db.SupabaseOrderWithItems
 import io.github.jan.supabase.postgrest.from
 import io.github.jan.supabase.postgrest.postgrest
 import io.github.jan.supabase.postgrest.rpc
@@ -9,13 +11,11 @@ import io.github.jan.supabase.postgrest.rpc
 class OrderRepository {
     private val client = SupabaseModule.client
 
-    suspend fun placeOrder(order: SupabaseOrder) {
+    suspend fun placeOrder(order: SupabaseOrder, item: SupabaseOrderItem) {
         client.postgrest.rpc(
             "place_order",
             mapOf(
                 "p_id" to order.id,
-                "p_stock_id" to order.stock_id,
-                "p_stock_name" to order.stock_name,
                 "p_recipient_name" to order.recipient_name,
                 "p_address" to order.address,
                 "p_phone" to order.phone,
@@ -24,6 +24,30 @@ class OrderRepository {
                 "p_note" to order.note
             )
         )
+
+        client.from("orderitems").insert(item)
+    }
+
+    suspend fun getOrderItems(orderId: String): List<SupabaseOrderItem> {
+        return client.from("orderitems")
+            .select { filter { eq("order_id", orderId) } }
+            .decodeList<SupabaseOrderItem>()
+    }
+
+    suspend fun getOrdersWithItems(): List<SupabaseOrderWithItems> {
+        val orders = getOrders()
+        return orders.map { order ->
+            val items = getOrderItems(order.id)
+            SupabaseOrderWithItems(order, items)
+        }
+    }
+
+    suspend fun getOrdersWithItemsByUserId(userId: String): List<SupabaseOrderWithItems> {
+        val orders = getOrdersByUserId(userId)
+        return orders.map { order ->
+            val items = getOrderItems(order.id)
+            SupabaseOrderWithItems(order, items)
+        }
     }
 
     suspend fun getOrders(): List<SupabaseOrder> {

--- a/app/src/main/java/com/example/rahmatmas/data/supabase/db/SupabaseOrder.kt
+++ b/app/src/main/java/com/example/rahmatmas/data/supabase/db/SupabaseOrder.kt
@@ -6,8 +6,6 @@ import kotlinx.serialization.Serializable
 data class SupabaseOrder(
     val id: String,
     val user_id: String?, // User ID from Supabase Auth
-    val stock_id: String,
-    val stock_name: String,
     val recipient_name: String,
     val address: String,
     val phone: String,

--- a/app/src/main/java/com/example/rahmatmas/data/supabase/db/SupabaseOrderItem.kt
+++ b/app/src/main/java/com/example/rahmatmas/data/supabase/db/SupabaseOrderItem.kt
@@ -1,0 +1,36 @@
+package com.example.rahmatmas.data.supabase.db
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SupabaseOrderItem(
+    val orderitem_id: String,
+    val order_id: String,
+    val id_stock: String,
+    val nama_stock: String,
+    val jumlah_order: Int,
+    val kadar_emas: String,
+    val kadar_persen: String,
+    val berat_emas: Double,
+    val ongkos_per_gram: Double,
+    val harga_emas_hariini: Double,
+    val total_harga: Double
+)
+
+data class SupabaseOrderWithItems(
+    val order: SupabaseOrder,
+    val items: List<SupabaseOrderItem>
+) : java.io.Serializable {
+    val id: String get() = order.id
+    val user_id: String? get() = order.user_id
+    val recipient_name: String get() = order.recipient_name
+    val address: String get() = order.address
+    val phone: String get() = order.phone
+    val note: String? get() = order.note
+    val shipping_option: String get() = order.shipping_option
+    val status: String get() = order.status
+    val created_at: String? get() = order.created_at
+    val updated_at: String? get() = order.updated_at
+    val cancel_reason: String? get() = order.cancel_reason
+    val cancelled_by: String? get() = order.cancelled_by
+}

--- a/app/src/main/java/com/example/rahmatmas/ui/admin/onlinesale/OnlineSaleAdminScreen.kt
+++ b/app/src/main/java/com/example/rahmatmas/ui/admin/onlinesale/OnlineSaleAdminScreen.kt
@@ -66,7 +66,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.rememberAsyncImagePainter
 import com.example.rahmatmas.R
 import com.example.rahmatmas.data.supabase.db.OrderStatus
-import com.example.rahmatmas.data.supabase.db.SupabaseOrder
+import com.example.rahmatmas.data.supabase.db.SupabaseOrderWithItems
 import com.example.rahmatmas.data.supabase.db.SupabaseStock
 import com.example.rahmatmas.data.supabase.db.toOrderStatus
 import java.text.SimpleDateFormat
@@ -302,7 +302,7 @@ fun OnlineSaleScreen(
                         items(currentOrders) { order ->
                             OrderCard(
                                 order = order,
-                                stockDetail = viewModel.getStockDetail(order.stock_id),
+                                stockDetail = viewModel.getStockDetail(order.items.firstOrNull()?.id_stock ?: ""),
                                 onStatusUpdate = { newStatus ->
                                     viewModel.updateOrderStatus(order.id, newStatus)
                                 },
@@ -331,7 +331,7 @@ fun OnlineSaleScreen(
 
 @Composable
 private fun OrderCard(
-    order: SupabaseOrder,
+    order: SupabaseOrderWithItems,
     stockDetail: SupabaseStock?,
     onStatusUpdate: (OrderStatus) -> Unit,
     onCancelClick: () -> Unit,
@@ -447,7 +447,7 @@ private fun OrderCard(
                     modifier = Modifier.weight(1f)
                 ) {
                     Text(
-                        text = order.stock_name,
+                        text = order.items.firstOrNull()?.nama_stock ?: "",
                         fontWeight = FontWeight.Bold,
                         fontSize = 14.sp,
                         color = Color(0xFF2C3E50),
@@ -686,7 +686,7 @@ private fun InfoRow(
 
 @Composable
 private fun CancelOrderDialog(
-    order: SupabaseOrder,
+    order: SupabaseOrderWithItems,
     onConfirm: (String) -> Unit,
     onDismiss: () -> Unit
 ) {
@@ -718,7 +718,7 @@ private fun CancelOrderDialog(
                 )
                 Spacer(modifier = Modifier.height(8.dp))
                 Text(
-                    text = "Pesanan: ${order.stock_name}",
+                    text = "Pesanan: ${order.items.firstOrNull()?.nama_stock}",
                     fontSize = 14.sp,
                     fontWeight = FontWeight.Medium
                 )

--- a/app/src/main/java/com/example/rahmatmas/ui/admin/onlinesale/OnlineSaleAdminViewModel.kt
+++ b/app/src/main/java/com/example/rahmatmas/ui/admin/onlinesale/OnlineSaleAdminViewModel.kt
@@ -7,7 +7,7 @@ import com.example.rahmatmas.data.network.NetworkMonitor
 import com.example.rahmatmas.data.repository.OrderRepository
 import com.example.rahmatmas.data.repository.StockRepository
 import com.example.rahmatmas.data.supabase.db.OrderStatus
-import com.example.rahmatmas.data.supabase.db.SupabaseOrder
+import com.example.rahmatmas.data.supabase.db.SupabaseOrderWithItems
 import com.example.rahmatmas.data.supabase.db.SupabaseStock
 import com.example.rahmatmas.data.supabase.db.toDbString
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -17,13 +17,13 @@ import kotlinx.coroutines.launch
 
 data class OnlineSaleUiState(
     val isLoading: Boolean = false,
-    val allOrders: List<SupabaseOrder> = emptyList(),
+    val allOrders: List<SupabaseOrderWithItems> = emptyList(),
     val selectedTabIndex: Int = 0,
     val errorMessage: String? = null,
     val isOnline: Boolean = true,
     val stockDetails: Map<String, SupabaseStock> = emptyMap(),
     val showCancelDialog: Boolean = false,
-    val selectedOrderForCancel: SupabaseOrder? = null
+    val selectedOrderForCancel: SupabaseOrderWithItems? = null
 )
 
 class OnlineSaleAdminViewModel(
@@ -63,7 +63,7 @@ class OnlineSaleAdminViewModel(
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isLoading = true)
             try {
-                val orders = orderRepository.getOrders()
+                val orders = orderRepository.getOrdersWithItems()
                 _uiState.value = _uiState.value.copy(
                     allOrders = orders,
                     isLoading = false,
@@ -82,10 +82,10 @@ class OnlineSaleAdminViewModel(
         }
     }
 
-    private fun loadStockDetails(orders: List<SupabaseOrder>) {
+    private fun loadStockDetails(orders: List<SupabaseOrderWithItems>) {
         viewModelScope.launch {
             try {
-                val stockIds = orders.map { it.stock_id }.distinct()
+                val stockIds = orders.mapNotNull { it.items.firstOrNull()?.id_stock }.distinct()
                 val stockDetailsMap = mutableMapOf<String, SupabaseStock>()
 
                 stockIds.forEach { stockId ->
@@ -105,13 +105,13 @@ class OnlineSaleAdminViewModel(
         _uiState.value = _uiState.value.copy(selectedTabIndex = index)
     }
 
-    fun getOrdersByStatus(status: OrderStatus): List<SupabaseOrder> {
+    fun getOrdersByStatus(status: OrderStatus): List<SupabaseOrderWithItems> {
         return _uiState.value.allOrders.filter {
             it.status.lowercase() == status.toDbString()
         }
     }
 
-    fun getCurrentTabOrders(): List<SupabaseOrder> {
+    fun getCurrentTabOrders(): List<SupabaseOrderWithItems> {
         return when (_uiState.value.selectedTabIndex) {
             0 -> getOrdersByStatus(OrderStatus.PENDING)
             1 -> getOrdersByStatus(OrderStatus.PROCESSING)
@@ -133,7 +133,7 @@ class OnlineSaleAdminViewModel(
         }
     }
 
-    fun showCancelDialog(order: SupabaseOrder) {
+    fun showCancelDialog(order: SupabaseOrderWithItems) {
         _uiState.value = _uiState.value.copy(
             showCancelDialog = true,
             selectedOrderForCancel = order

--- a/app/src/main/java/com/example/rahmatmas/ui/customer/checkout/CheckoutViewModel.kt
+++ b/app/src/main/java/com/example/rahmatmas/ui/customer/checkout/CheckoutViewModel.kt
@@ -5,7 +5,9 @@ import androidx.lifecycle.viewModelScope
 import com.example.rahmatmas.data.repository.OrderRepository
 import com.example.rahmatmas.data.supabase.SupabaseModule
 import com.example.rahmatmas.data.supabase.db.SupabaseOrder
+import com.example.rahmatmas.data.supabase.db.SupabaseOrderItem
 import com.example.rahmatmas.data.supabase.db.SupabaseStock
+import com.example.rahmatmas.data.repository.GoldPriceRepository
 import io.github.jan.supabase.auth.auth
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -27,6 +29,7 @@ data class CheckoutUiState(
 class CheckoutViewModel : ViewModel() {
     private val orderRepository = OrderRepository()
     private val supabaseClient = SupabaseModule.client
+    private val goldPriceRepository = GoldPriceRepository()
 
     private val _uiState = MutableStateFlow(CheckoutUiState())
     val uiState: StateFlow<CheckoutUiState> = _uiState.asStateFlow()
@@ -118,8 +121,6 @@ class CheckoutViewModel : ViewModel() {
                 val order = SupabaseOrder(
                     id = orderId,
                     user_id = currentUser.id, // Use authenticated user ID
-                    stock_id = stock.id_barang,
-                    stock_name = stock.nama_barang,
                     recipient_name = name.trim(),
                     address = address.trim(),
                     phone = phone.trim(),
@@ -132,7 +133,27 @@ class CheckoutViewModel : ViewModel() {
                     cancelled_by = null
                 )
 
-                orderRepository.placeOrder(order)
+                val goldPriceResponse = goldPriceRepository.getGoldPrice()
+                val hargaEmas = goldPriceResponse.body()?.data?.firstOrNull()?.sell?.toDoubleOrNull() ?: 0.0
+                val kadarPersen = stock.kadar_persen.replace("%", "").toDoubleOrNull() ?: 0.0
+                val hargaDasarPerGram = (hargaEmas * kadarPersen / 100)
+                val totalHarga = hargaDasarPerGram * stock.berat_emas
+
+                val orderItem = SupabaseOrderItem(
+                    orderitem_id = "ITEM-${UUID.randomUUID()}",
+                    order_id = orderId,
+                    id_stock = stock.id_barang,
+                    nama_stock = stock.nama_barang,
+                    jumlah_order = 1,
+                    kadar_emas = stock.kadar_emas,
+                    kadar_persen = stock.kadar_persen,
+                    berat_emas = stock.berat_emas,
+                    ongkos_per_gram = stock.ongkos_per_gram,
+                    harga_emas_hariini = hargaEmas,
+                    total_harga = totalHarga
+                )
+
+                orderRepository.placeOrder(order, orderItem)
 
                 _uiState.value = _uiState.value.copy(
                     isLoading = false,

--- a/app/src/main/java/com/example/rahmatmas/ui/customer/orderstatus/OrderStatusScreen.kt
+++ b/app/src/main/java/com/example/rahmatmas/ui/customer/orderstatus/OrderStatusScreen.kt
@@ -60,7 +60,7 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.rahmatmas.R
 import com.example.rahmatmas.data.supabase.db.OrderStatus
-import com.example.rahmatmas.data.supabase.db.SupabaseOrder
+import com.example.rahmatmas.data.supabase.db.SupabaseOrderWithItems
 import com.example.rahmatmas.data.supabase.db.toOrderStatus
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -245,7 +245,7 @@ fun OrderStatusScreen(
                 LazyColumn(
                     verticalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
-                    items(uiState.orders) { order ->
+                        items(uiState.orders) { order ->
                         CustomerOrderCard(
                             order = order,
                             onCancelClick = {
@@ -272,7 +272,7 @@ fun OrderStatusScreen(
 
 @Composable
 private fun CustomerOrderCard(
-    order: SupabaseOrder,
+    order: SupabaseOrderWithItems,
     onCancelClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -343,7 +343,7 @@ private fun CustomerOrderCard(
 
             // Product name
             Text(
-                text = order.stock_name,
+                    text = order.items.firstOrNull()?.nama_stock ?: "",
                 fontWeight = FontWeight.Bold,
                 fontSize = 15.sp,
                 color = Color(0xFF2C3E50)
@@ -555,7 +555,7 @@ private fun OrderProgressIndicator(
 
 @Composable
 private fun CustomerCancelOrderDialog(
-    order: SupabaseOrder,
+    order: SupabaseOrderWithItems,
     onConfirm: (String) -> Unit,
     onDismiss: () -> Unit
 ) {
@@ -587,7 +587,7 @@ private fun CustomerCancelOrderDialog(
                 )
                 Spacer(modifier = Modifier.height(8.dp))
                 Text(
-                    text = "Pesanan: ${order.stock_name}",
+                    text = "Pesanan: ${order.items.firstOrNull()?.nama_stock}",
                     fontSize = 14.sp,
                     fontWeight = FontWeight.Medium
                 )

--- a/app/src/main/java/com/example/rahmatmas/ui/customer/orderstatus/OrderStatusViewModel.kt
+++ b/app/src/main/java/com/example/rahmatmas/ui/customer/orderstatus/OrderStatusViewModel.kt
@@ -7,7 +7,7 @@ import com.example.rahmatmas.data.network.NetworkMonitor
 import com.example.rahmatmas.data.repository.OrderRepository
 import com.example.rahmatmas.data.supabase.SupabaseModule
 import com.example.rahmatmas.data.supabase.db.OrderStatus
-import com.example.rahmatmas.data.supabase.db.SupabaseOrder
+import com.example.rahmatmas.data.supabase.db.SupabaseOrderWithItems
 import com.example.rahmatmas.data.supabase.db.toDbString
 import io.github.jan.supabase.auth.auth
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -17,14 +17,14 @@ import kotlinx.coroutines.launch
 
 data class OrderStatusUiState(
     val isLoading: Boolean = false,
-    val orders: List<SupabaseOrder> = emptyList(),
+    val orders: List<SupabaseOrderWithItems> = emptyList(),
     val userEmail: String = "",
     val userName: String = "",
     val userId: String = "",
     val errorMessage: String? = null,
     val isOnline: Boolean = true,
     val showCancelDialog: Boolean = false,
-    val selectedOrderForCancel: SupabaseOrder? = null
+    val selectedOrderForCancel: SupabaseOrderWithItems? = null
 )
 
 class OrderStatusViewModel(
@@ -91,7 +91,7 @@ class OrderStatusViewModel(
             try {
                 // Use getCurrentUserOrders which should use RLS (Row Level Security)
                 // or getOrdersByUserId with current user ID
-                val orders = orderRepository.getOrdersByUserId(currentUser.id)
+                val orders = orderRepository.getOrdersWithItemsByUserId(currentUser.id)
                 _uiState.value = _uiState.value.copy(
                     isLoading = false,
                     orders = orders
@@ -109,7 +109,7 @@ class OrderStatusViewModel(
         loadUserOrders()
     }
 
-    fun showCancelDialog(order: SupabaseOrder) {
+    fun showCancelDialog(order: SupabaseOrderWithItems) {
         _uiState.value = _uiState.value.copy(
             showCancelDialog = true,
             selectedOrderForCancel = order


### PR DESCRIPTION
## Summary
- split `SupabaseOrderItem` into its own model and link each item to its order
- load order items by `order_id` when fetching orders
- generate unique item IDs during checkout

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af0468c03c83319963a91da80fd3f5